### PR TITLE
Bug 1090306 - [Loop] Loop remains blocked in screen "Opps! That didn't work....", calling from call log entry previously generated by an URL-browser call

### DIFF
--- a/app/call_screen/js/call_manager.js
+++ b/app/call_screen/js/call_manager.js
@@ -563,7 +563,7 @@
           resolve();
         }
 
-        function _waitForInitialized() {
+        function _waitForInitialized(error) {
           var secureTimeout = setTimeout(
             function() {
               _resolvePromise(error);

--- a/app/call_screen/js/call_screen_ui.js
+++ b/app/call_screen/js/call_screen_ui.js
@@ -585,6 +585,7 @@
       });
     },
     abortCall: function(error) {
+      TonePlayerHelper.init('telephony');
       if (error && error.reason) {
         this.notifyCallFailed(error);
         return;


### PR DESCRIPTION
See bug https://bugzilla.mozilla.org/show_bug.cgi?id=1090306 please.
