### PR TITLE
added audio and video codec names in telemetry report

### DIFF
--- a/app/call_screen/js/call_manager.js
+++ b/app/call_screen/js/call_manager.js
@@ -38,6 +38,8 @@
   var _isVideoCall = false;
   var _peersConnection = null;
   var _acm = navigator.mozAudioChannelManager;
+  var _videoCodecName = 'unknown';
+  var _audioCodecName = 'unknown';
 
   // These strings will be found in SDP answer if H264 video codec is used
   const H264_STRING_126 = 'a=rtpmap:126 H264';
@@ -455,24 +457,23 @@
                 return;
               }
 
-              var videoCodecName, audioCodecName, description;
+              var description;
               description = _publisher.answerSDP;
               if (description.indexOf(H264_STRING_126) != -1 || 
                   description.indexOf(H264_STRING_97) != -1) {
-                videoCodecName = 'H264';
+                _videoCodecName = 'H264';
               } else if (description.indexOf(VP8_STRING) != -1) {
-                videoCodecName = 'VP8';
+                _videoCodecName = 'VP8';
               } else {
-                videoCodecName = 'Unknown';
+                _videoCodecName = 'unknown';
               }
-              debug && console.log("Video Codec used: " + videoCodecName);
-
+              debug && console.log("Video Codec used: " + _videoCodecName);
               if (description.indexOf(OPUS_STRING) != -1) {
-                audioCodecName = 'OPUS';
+                _audioCodecName = 'OPUS';
               } else {
-                audioCodecName = 'Unknown';
+                _audioCodecName = 'unknown';
               }
-              debug && console.log("Audio Codec used: " + audioCodecName);
+              debug && console.log("Audio Codec used: " + _audioCodecName);
             }
           });
           _publishersInSession += 1;
@@ -694,6 +695,8 @@
           duration: duration,
           connected: connected,
           video: _isVideoCall,
+          videoCodecName: _videoCodecName,
+          audioCodecName: _audioCodecName,
           feedback: feedback || null
         };
 

--- a/app/js/helpers/call_screen_manager.js
+++ b/app/js/helpers/call_screen_manager.js
@@ -227,7 +227,8 @@
             CallLog.addCall(callObject);
             cleanCallParams();
           });
-
+          Telemetry.recordAudioCodec(callscreenParams.audioCodecName);
+          Telemetry.recordVideoCodec(callscreenParams.videoCodecName);
           Telemetry.recordCallDuration(callObject.duration);
           break;
       }

--- a/app/js/helpers/telemetry.js
+++ b/app/js/helpers/telemetry.js
@@ -33,7 +33,8 @@
   // We only care about cellular or wifi.
   const CALLS_WITH_CELLULAR = 'callsWithCellular';
   const CALLS_WITH_WIFI = 'callsWithWifi';
-
+  const AUDIO_CODEC_NAME = 'audioCodecName';
+  const VIDEO_CODEC_NAME = 'videoCodecName';
   const LAST_REPORT = 'telemetry-last-report';
 
   const THROTTLE_DELAY = 10 * 1000; // 10 sec
@@ -78,6 +79,8 @@
        this[type] = 0;
     });
     this[CALLS_DURATION] = [];
+    this[AUDIO_CODEC_NAME] = [];
+    this[VIDEO_CODEC_NAME] = [];
   }
 
   function Telemetry() {
@@ -148,8 +151,19 @@
 
         if (!report) {
           report = new TelemetryReport();
+        } else {
+          if (report[type] == undefined) {
+            var newReport = new TelemetryReport();
+            // Copy the new fields..
+            for(var key in newReport) {
+              if (report[key] == undefined) {
+                report[key] = newReport[key];
+              }
+              delete newReport[key];
+            }
+            newReport = null; // freeing newReport
+          }
         }
-
         if (report[type] == undefined) {
           throw new Error('Unknown metric type ' + type);
         }
@@ -227,6 +241,20 @@
         return;
       }
       this._updateReport(CALLS_DURATION, duration);
+    },
+
+    recordAudioCodec: function(codec) {
+      if (codec == undefined || codec == null) {
+        return;
+      }
+      this._updateReport(AUDIO_CODEC_NAME, codec);
+    },
+
+    recordVideoCodec: function(codec) {
+      if (codec == undefined || codec == null) {
+        return;
+      }
+      this._updateReport(VIDEO_CODEC_NAME, codec);
     }
 
   };


### PR DESCRIPTION
now telemetry report has two new parameters, audioName and videoName. Both are arrays to save the AV codec name used in each call.
