### PR TITLE
Bug 1113565 - [Loop] Wrong or confusing message trying to authenticate (MobileID WITHOUT physical SIM card), with wrong mobile date (e.g. one year before)

### DIFF
--- a/app/js/helpers/account_helper.js
+++ b/app/js/helpers/account_helper.js
@@ -265,7 +265,7 @@
   }
 
   function _onloginerror(error) {
-    debug && console.log('onloginerror ' + error);
+    debug && console.log('onloginerror');
 
     _isIdFlowRunning = false;
     _isLogged = false;
@@ -293,7 +293,11 @@
       onerror: function(err) {
         var errorName = JSON.parse(err).name;
         if (errorName !== 'OFFLINE') {
-          _onloginerror();
+          Loader.getSignUpErrorScreen().then(SignUpErrorScreen => {
+            var _ = navigator.mozL10n.get;
+            SignUpErrorScreen.show(_('signUpFail'));
+            _onloginerror();
+          });
           return;
         }
         debug && console.log('FxA: OFFLINE error');
@@ -395,7 +399,15 @@
         case 'msisdn':
           navigator.getMobileIdAssertion({
             forceSelection: true
-          }).then(_onlogin, _onloginerror);
+          }).then(
+            _onlogin,
+            () => {
+              Loader.getSignUpErrorScreen().then(SignUpErrorScreen => {
+                var _ = navigator.mozL10n.get;
+                SignUpErrorScreen.show(_('signUpFail'));
+                _onloginerror();
+              });
+            });
           Telemetry.updateReport('mobileIdLogins');
           break;
         default:

--- a/app/js/helpers/loader.js
+++ b/app/js/helpers/loader.js
@@ -314,6 +314,21 @@
           }
         );
       });
+    },
+    getSignUpErrorScreen: function() {
+      if (window.SignUpErrorScreen) {
+        return Promise.resolve(SignUpErrorScreen);
+      }
+      return new Promise((resolve, reject) => {
+        LazyLoader.load(
+          [
+            'js/screens/error_screen.js'
+          ],
+          () => {
+            resolve(SignUpErrorScreen);
+          }
+        );
+      });
     }
   };
 

--- a/app/js/screens/error_screen.js
+++ b/app/js/screens/error_screen.js
@@ -47,14 +47,13 @@
     };
   }
 
-  function _openFxASettings(evt) {
+  function _openSettings(evt) {
     _hide(evt);
 
     var activity = new window.MozActivity({
       name: 'configure',
       data: {
-        target: 'device',
-        section: 'fxa'
+        target: 'device'
       }
     });
 
@@ -85,7 +84,7 @@
         _onSettingsClicked = _openConnectivitySettings;
         break;
       case 'signuperror':
-        _onSettingsClicked = _openFxASettings;
+        _onSettingsClicked = _openSettings;
         break;
       default:
         _onSettingsClicked = _noop;

--- a/app/locales/loop.en-US.properties
+++ b/app/locales/loop.en-US.properties
@@ -158,8 +158,8 @@ invalidRoomToken = Oops... You can’t join this room. It may be expired or dele
 cameraPermission = We can't access your microphone and camera because you didn't give us permission. To use {{serviceName}}, please grant them in Settings > App permissions > {{serviceName}}
 notCompatibleDevice = Sorry, your device isn't compatible with this app
 oldOSVersion = Sorry, this app requires Firefox OS 2.0 or later
-signUpFail = Sorry, due to problems on our side your account session has expired. Please try logging in again. If the problem persists, you might need to log out from Firefox Accounts on the Settings App.
-signInFail = Sorry, due to problems on our side your account session has expired. Please, login again.
+signUpFail = Sorry, the logging process failed. Please, try again. If the problem persists and you are logged in Firefox Accounts you might need to log out or check time settings on the Settings App.
+signInFail = Sorry, your session has expired. Please, try again.
 newUpdateAvailable = Required update: There is an update with new features. Do you want to download it? This update is required to continue using {{serviceName}}
 
 # Offline support

--- a/app/locales/loop.es.properties
+++ b/app/locales/loop.es.properties
@@ -157,8 +157,8 @@ invalidRoomToken = Ups... no puede unirse a la room, pudo haber expirado o sido 
 cameraPermission = No tenemos acceso al micrófono ni la cámara porque no nos diste permiso. Para usar {{serviceName}}, por favor cambia estos permisos en Ajustes > Permisos de aplicaciones > {{serviceName}}
 notCompatibleDevice = Lo sentimos, tu dispositivo no es compatible con esta aplicación
 oldOSVersion = Lo sentimos, esta aplicación requiere Firefox OS 2.0 o posterior
-signUpFail = Lo sentimos, por problemas en nuestro lado la sesión de tu cuenta ha caducado. Por favor, regístrate otra vez. Si el problema persiste quizá necesites salir de Firefox Account en ajustes.
-signInFail = Lo sentimos, por problemas en nuestro lado la sesión de tu cuenta ha caducado. Por favor, regístrate otra vez.
+signUpFail = Lo sentimos, el registro falló. Por favor, regístrate otra vez. Si el problema persiste y usas Firefox Account quizá necesites salir o cambiar hora y fecha en ajustes.
+signInFail = Lo sentimos, tu sesión ha caducado. Por favor, regístrate otra vez.
 newUpdateAvailable = Actualización obligatoria: Hay una nueva actualización con nuevas funcionalidades. ¿Quieres descargártela? Esta actualización es necesaria para continuar utilizando {{serviceName}}
 
 # Offline support


### PR DESCRIPTION
See bug https://bugzilla.mozilla.org/show_bug.cgi?id=1113565. Action happens at https://github.com/jaoo/firefoxos-loop-client/tree/1113565.