### PR TITLE
Bug 1120893 - [Loop] Notification isn't available in utility tray

### DIFF
--- a/app/js/config.js
+++ b/app/js/config.js
@@ -1,6 +1,6 @@
 Config = {
   version: '1.1.1d',
-  debug: false,
+  debug: true,
   // Server URL. It might be (depending on the environment):
   //   Development: 'https://loop-dev.stage.mozaws.net'
   //   Stage: 'https://loop.stage.mozaws.net'


### PR DESCRIPTION
See bug https://bugzilla.mozilla.org/show_bug.cgi?id=1120893 please. Action happens at https://github.com/jaoo/firefoxos-loop-client/tree/1120893.
