### PR TITLE
Bug 1121338 - [Loop] Audio/Video codec identification for Rooms

### DIFF
--- a/app/call_screen/js/call_manager.js
+++ b/app/call_screen/js/call_manager.js
@@ -37,17 +37,8 @@
   var _isVideoCall = false;
   var _peersConnection = null;
   var _acm = navigator.mozAudioChannelManager;
-  var _videoCodecName = 'unknown';
-  var _audioCodecName = 'unknown';
   var _usedCamera = 'none';
-
-  // These strings will be found in SDP answer if H264 video codec is used
-  const H264_STRING_126 = 'a=rtpmap:126 H264';
-  const H264_STRING_97 = 'a=rtpmap:97 H264';
-  // This string will be found in SDP answer if VP8 video codec is used
-  const VP8_STRING = 'a=rtpmap:120 VP8';
-  // This string will be found in SDP answer if OPUS audio codec is used
-  const OPUS_STRING = 'a=rtpmap:109 opus';
+  var _codec = {};
 
   const TIMEOUT_SHIELD = 5000;
   const MEAN_ELEMENTS = 16;
@@ -474,6 +465,7 @@
                   }, TIME_INTERVAL_SECONDS * 1000);
                 }
               }
+
             }
           });
           _publishersInSession += 1;
@@ -689,14 +681,17 @@
         connected = true;
       }
 
+      _codec = CodecHelper.getAVCodecNames(_publisher);
+      debug && console.log('Codecs Used video:' + _codec.video +
+       ' audio:'+_codec.audio);
       function sendParams(message, feedback) {
         var params = {
           call: _call,
           duration: duration,
           connected: connected,
           video: _isVideoCall,
-          videoCodecName: _videoCodecName,
-          audioCodecName: _audioCodecName,
+          videoCodecName: _codec.video,
+          audioCodecName: _codec.audio,
           usedCamera: _usedCamera,
           feedback: feedback || null
         };
@@ -717,24 +712,6 @@
         ControllerCommunications.send(message);
       }
 
-      if (_publisher && _publisher.answerSDP) {
-        var description = _publisher.answerSDP;
-        if (description.indexOf(H264_STRING_126) != -1 ||
-            description.indexOf(H264_STRING_97) != -1) {
-          _videoCodecName = 'H264';
-        } else if (description.indexOf(VP8_STRING) != -1) {
-          _videoCodecName = 'VP8';
-        } else {
-          _videoCodecName = 'unknown';
-        }
-        debug && console.log("Video Codec used: " + _videoCodecName);
-        if (description.indexOf(OPUS_STRING) != -1) {
-          _audioCodecName = 'OPUS';
-        } else {
-          _audioCodecName = 'unknown';
-        }
-        debug && console.log("Audio Codec used: " + _audioCodecName);
-      }
       // Send hangout message to Controller
       sendParams('hangout');
 

--- a/app/call_screen/js/call_screen_ui_minified.js
+++ b/app/call_screen/js/call_screen_ui_minified.js
@@ -78,6 +78,7 @@
         '../js/helpers/tone_player_helper.js',
         '../js/helpers/audio_competing_helper.js',
         '../js/helpers/countdown.js',
+        '../js/helpers/codec_helper.js',
         'js/ringer.js',
         'js/call_manager.js',
         '../js/branding.js',

--- a/app/js/helpers/codec_helper.js
+++ b/app/js/helpers/codec_helper.js
@@ -1,0 +1,42 @@
+'use strict';
+
+(function(exports) {
+  // These strings will be found in SDP answer if H264 video codec is used
+  const H264_STRING_126 = 'a=rtpmap:126 H264';
+  const H264_STRING_97 = 'a=rtpmap:97 H264';
+  // This string will be found in SDP answer if VP8 video codec is used
+  const VP8_STRING = 'a=rtpmap:120 VP8';
+  // This string will be found in SDP answer if OPUS audio codec is used
+  const OPUS_STRING = 'a=rtpmap:109 opus';
+
+  var CodecHelper = {
+    getAVCodecNames: function ut_getAVCodecNames(publisher) {
+
+      var codecName = {audio: 'unknown',
+                       video: 'unknown'};
+      if (!publisher && !publisher.answerSDP) {
+        return codecName
+      }
+      var description = publisher.answerSDP;
+      if (!description){
+        return codecName;
+      }
+      if (description.indexOf(H264_STRING_126) != -1 ||
+          description.indexOf(H264_STRING_97) != -1) {
+        codecName.video = 'H264';
+      } else if (description.indexOf(VP8_STRING) != -1) {
+        codecName.video = 'VP8';
+      } else {
+        codecName.video = 'unknown';
+      }
+      if (description.indexOf(OPUS_STRING) != -1) {
+        codecName.audio = 'OPUS';
+      } else {
+        codecName.audio = 'unknown';
+      }
+      return codecName;
+    }
+  };
+
+  exports.CodecHelper = CodecHelper;
+}(this));

--- a/app/js/helpers/loader.js
+++ b/app/js/helpers/loader.js
@@ -280,6 +280,7 @@
           [
             'libs/tokbox/' + window.OTProperties.version + '/js/TB.js',
             'libs/opentok.js',
+            'js/helpers/codec_helper.js',
             'js/helpers/room/room_manager.js'
           ],
           () => {

--- a/app/js/helpers/room/room_manager.js
+++ b/app/js/helpers/room/room_manager.js
@@ -193,6 +193,11 @@
     },
 
     leave: function() {
+      var codec = CodecHelper.getAVCodecNames(publisher);
+      debug && console.log('Codecs Used video:' + codec.video +
+        ' audio:'+ codec.audio);
+      Telemetry.updateReport('audioCodecName', codec.audio);
+      Telemetry.updateReport('videoCodecName', codec.video);
       disconnectSession();
       publisher = subscriber = null;
       subscribers = null;
@@ -202,6 +207,11 @@
     },
 
     interrupt: function() {
+      var codec = CodecHelper.getAVCodecNames(publisher);
+      debug && console.log('Codecs Used video:' + codec.video +
+        ' audio:'+ codec.audio);
+      Telemetry.updateReport('audioCodecName', codec.audio);
+      Telemetry.updateReport('videoCodecName', codec.video);
       disconnectSession();
       publisher = subscriber = null;
       subscribers = null;


### PR DESCRIPTION
This code, for rooms, is exactly the same that the one in call_screen/js/call_manager.js (conversations).
Maybe it should be convenient to create a new file with all video measurements and info in a unique such file so these common functions and constants should be written once?