### PR TITLE
Bug 1124632 - German translations for 'Terms of Service' and 'Privacy No...

### DIFF
--- a/app/style/wizard.css
+++ b/app/style/wizard.css
@@ -517,6 +517,7 @@
 }
 
 #wizard-login .gaia-footer p {
+  word-break: keep-all;
   text-align: center;
   color: #fff;
   font-size: 1.3rem;


### PR DESCRIPTION
...tice' long, 'Privacy Notice' gets wrapped in the middle of the word r=crdlc