### PR TITLE
Bug 1126313 - [Loop] Device in silent mode manage notifications in a different way depending if owner is in the room or not

### DIFF
--- a/app/js/controller.js
+++ b/app/js/controller.js
@@ -291,7 +291,7 @@
 
                   Loader.getNotificationHelper().then(
                     function(NotificationHelper) {
-                      TonePlayerHelper.init('publicnotification');
+                      TonePlayerHelper.init('notification');
                       TonePlayerHelper.playSomeoneJoinedARoomYouOwn();
 
                       ContactsHelper.getParticipantName(participant).then(

--- a/app/manifest.webapp
+++ b/app/manifest.webapp
@@ -23,6 +23,9 @@
     "moz-audio-channel-telephony": {
       "description": "Allow Firefox Hello to route the audio call through the telephony channel. This permission is required to be able to switch between Firefox Hello and GSM calls"
     },
+    "audio-channel-notification": {
+      "description": "Allow Firefox Hello to play a sound notification when someone joins a room the logged user owns"
+    },
     "camera": {
       "description": "Give Firefox Hello control to toggle between the front and rear cameras in your device if they are available"
     },


### PR DESCRIPTION
See bug https://bugzilla.mozilla.org/show_bug.cgi?id=1126313 please. Action happens at https://github.com/jaoo/firefoxos-loop-client/tree/1126313.