### PR TITLE
Bug 1129951 - [Loop] If the room call is terminated by any reason, the user *isn't* notified about that

### DIFF
--- a/app/js/helpers/room/room_controller.js
+++ b/app/js/helpers/room/room_controller.js
@@ -481,8 +481,12 @@
                   var current = new Date().getTime();
                   debug && console.log('Room participant left');
                   Rooms.get(currentToken).then(room => {
-                    _participants = room.participants;
-                    setNumberParticipants(_participants.length);
+                    var participants = _participants = room.participants.length;
+                    if (event && event.connectionEvent &&
+                        (event.connectionEvent.reason === 'networkDisconnected')) {
+                      participants-=1;
+                    }
+                    setNumberParticipants(participants);
                   });
                   RoomUI.setWaiting();
                   _logEventCommunication (current);

--- a/app/js/helpers/room/room_manager.js
+++ b/app/js/helpers/room/room_manager.js
@@ -135,6 +135,17 @@
             });
           },
 
+          sessionDisconnected: function(event) {
+            if (event && (event.reason === 'networkDisconnected')) {
+              // tokbox.com/opentok/libraries/client/js/reference/Error.html
+              this.dispatchEvent(
+                new OT.ErrorEvent(OT.RoomManager.EventNames.ERROR,
+                                  1006,
+                                  'Connect failed')
+              );
+            }
+          },
+
           connectionCreated: function(event) {
             // The Session object dispatches a connectionCreated event when a
             // client (including your own) connects to a Session so we should
@@ -156,9 +167,7 @@
 
           connectionDestroyed: function(event) {
             // Fire an OT.RoomManager.EventNames.PARTICIPANT_LEFT event.
-            this.dispatchEvent(
-              new OT.Event(OT.RoomManager.EventNames.PARTICIPANT_LEFT)
-            );
+            this.dispatchEvent(new OT.ParticipantLeftEvent(event));
           },
 
           streamCreated: function(event) {
@@ -302,6 +311,14 @@
     LEFT: 'left',
     ERROR: 'error',
     INTERRUPT: 'interrupt'
+  };
+
+  OT.ParticipantLeftEvent = function(connectionEvent) {
+    OT.Event.call(this,
+                  OT.RoomManager.EventNames.PARTICIPANT_LEFT,
+                  false);
+
+    this.connectionEvent = connectionEvent;
   };
 
   OT.ErrorEvent = function(type, code, message) {


### PR DESCRIPTION
See bug https://bugzilla.mozilla.org/show_bug.cgi?id=1129951 please. Action happens at https://github.com/jaoo/firefoxos-loop-client/tree/1129951.