### PR TITLE
Fixed orientation, #574

### DIFF
--- a/app/manifest.webapp
+++ b/app/manifest.webapp
@@ -110,7 +110,6 @@
     "126": "/style/images/icons/Icon_Hello@1.5.png",
     "168": "/style/images/icons/Icon_Hello@2.png"
   },
-  "orientation": "portrait",
   "origin": "app://loop.services.mozilla.com",
   "version": "1.1.1d"
 }


### PR DESCRIPTION
Removed "orientation":"portrait" from manifest.webapp in order to follow device orientation (useful for tablets)
